### PR TITLE
fix(Windows): adding '.exe' to leptosfmtPath

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,7 +39,8 @@ export function activate(context: vscode.ExtensionContext) {
 
   const cargoHome = customCargoHome || defaultCargoHome;
   channel.appendLine(`Cargo home being used is: ${cargoHome}`);
-  const leptosfmtPath = customLeptosfmtPath || path.join(cargoHome, 'bin', 'leptosfmt');
+  const leptosfmtPathExtension = process.platform === 'win32' ? '.exe' : '';
+  const leptosfmtPath = customLeptosfmtPath || path.join(cargoHome, 'bin', `leptosfmt${leptosfmtPathExtension}`);
   channel.appendLine(`leptosfmt path being used is: ${leptosfmtPath}`);
 
   if (!fs.existsSync(leptosfmtPath)) {


### PR DESCRIPTION
To avoid this error message when launching this extension on Windows:

![image](https://github.com/user-attachments/assets/2dacb155-9bc0-4d1e-a482-7f0dc3d9cb95)

I tested it in debug mode, the error message is not shown with this fix. Note that this is also working on Windows x64.

Sorry I didn't add nor modify any test, I don't quite understand how this is working.

If I write a test that is supposed to fail 

```ts
test('Check for leptosfmt installation', async () => {
    const leptosfmtPath = path.join(process.env.HOME || '', '.cargo', 'bin', 'leptosfmt');
    exec(`ls ${leptosfmtPath}`, (error, stdout, stderr) => {
        assert.fail('FOO');
    });
});
```

The test passes, no fail at all...
If the ` assert.fail` is written outside the `exec` then the test fails as it's supposed to.

So there might be an issue with the tests actually.